### PR TITLE
add mmap module

### DIFF
--- a/fio/mmap.go
+++ b/fio/mmap.go
@@ -1,0 +1,85 @@
+package fio
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+	"sync/atomic"
+	"syscall"
+)
+
+const size = 1024 * 1024 * 256
+
+type MmapIO struct {
+	fd     *os.File //系统文件描述符
+	data   []byte
+	offset int64 // 用于记录写入位置
+}
+
+func NewMmapIOManager(filePath string) (*MmapIO, error) {
+	fd, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, DataFilePerm)
+	if err := fd.Truncate(size); err != nil {
+		return nil, err
+	}
+	data, err := syscall.Mmap(int(fd.Fd()), 0, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, err
+	}
+	return &MmapIO{
+		fd:     fd,
+		data:   data,
+		offset: 0,
+	}, nil
+}
+
+func (fd *MmapIO) Read(data []byte, pos int64) (int, error) {
+	start := int(pos)
+	end := start + len(data)
+	if start >= len(fd.data) {
+		return 0, nil
+	}
+	if end > len(fd.data) {
+		end = len(fd.data)
+	}
+	return copy(data, fd.data[start:end]), nil
+}
+
+func (fd *MmapIO) Write(data []byte) (int, error) {
+	currentOffset := atomic.LoadInt64(&fd.offset)        // 获取当前写入位置
+	requiredCapacity := currentOffset + int64(len(data)) // 计算所需的容量
+
+	// 如果 fd.data 的容量不足以容纳所需的容量，进行扩容
+	if int64(cap(fd.data)) < requiredCapacity {
+		newCapacity := requiredCapacity + 1024 // 增加一些额外的容量
+		newData := make([]byte, requiredCapacity, newCapacity)
+		copy(newData, fd.data)
+		fd.data = newData
+	}
+
+	newData := append(fd.data[:currentOffset], data...)    // 将新数据追加到原有数据之后
+	copy(fd.data[currentOffset:], newData[currentOffset:]) // 将追加后的数据复制到 fd.data
+	atomic.AddInt64(&fd.offset, int64(len(data)))          // 更新写入位置
+	return len(data), nil
+}
+
+func (fd *MmapIO) Sync() error {
+	return unix.Msync(fd.data, syscall.MS_SYNC)
+}
+
+func (fd *MmapIO) Close() error {
+	if err := syscall.Munmap(fd.data); err != nil {
+		return err
+	}
+	return fd.fd.Close()
+}
+
+func (fd *MmapIO) Size() (int64, error) {
+	fileInfo, err := fd.fd.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return fileInfo.Size(), nil
+}
+
+func NewIOManager(filename string) (IOManager, error) {
+	return NewMmapIOManager(filename)
+}

--- a/fio/mmap_test.go
+++ b/fio/mmap_test.go
@@ -1,0 +1,120 @@
+package fio
+
+import (
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewMMapIOManager(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	defer destoryFile(path)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+}
+
+func TestMMapIO_Write(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	defer destoryFile(path)
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+
+	n, err := mio.Write([]byte(""))
+	assert.Equal(t, 0, n)
+	assert.Nil(t, err)
+
+	n, err = mio.Write([]byte("bitcask kv"))
+	assert.Equal(t, 10, n)
+	assert.Nil(t, err)
+	n, err = mio.Write([]byte("storage"))
+	assert.Equal(t, 7, n)
+	assert.Nil(t, err)
+}
+
+func TestMMapIO_Read(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	defer destoryFile(path)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+
+	_, err = mio.Write([]byte("key-a"))
+	assert.Nil(t, err)
+	_, err = mio.Write([]byte("key-b"))
+	assert.Nil(t, err)
+
+	b1 := make([]byte, 5)
+	n, err := mio.Read(b1, 0)
+
+	assert.Equal(t, 5, n)
+	assert.Equal(t, []byte("key-a"), b1)
+
+	b2 := make([]byte, 5)
+	n, err = mio.Read(b2, 5)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, []byte("key-b"), b2)
+}
+
+func TestMMapIO_Sync(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	defer destoryFile(path)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+
+	_, err = mio.Write([]byte("key-c"))
+	err = mio.Sync()
+	assert.Nil(t, err)
+}
+
+func TestMMapIO_Close(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	defer destoryFile(path)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+
+	_, err = mio.Write([]byte("key-a"))
+	assert.Nil(t, err)
+
+	err = mio.Close()
+	assert.Nil(t, err)
+}
+
+func TestMMapIO_Write_Speed(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+
+	for i := 0; i < 1000000; i++ {
+		n, err := mio.Write([]byte("bitcask kv"))
+		assert.Equal(t, 10, n)
+		assert.Nil(t, err)
+	}
+
+	err = mio.Close()
+	assert.Nil(t, err)
+}
+
+func TestMMapIO_Read_Speed(t *testing.T) {
+	path := filepath.Join("/tmp", "a.data")
+	mio, err := NewMmapIOManager(path)
+	defer destoryFile(path)
+	assert.Nil(t, err)
+	assert.NotNil(t, mio)
+
+	for i := 0; i < 1000000; i++ {
+		b1 := make([]byte, 10)
+		n, err := mio.Read(b1, int64(i*10))
+		assert.Equal(t, 10, n)
+		assert.Nil(t, err)
+		//assert.Equal(t, []byte("bitcask kv"), b1)
+	}
+}


### PR DESCRIPTION
在mmap_test.go文件中，测试均通过
在benchmark_test.go文件中，执行BenchmarkDB_Put方法，运行通过
具体内容如下图所示
![de06047adee5b02573c843e50e08780](https://github.com/ByteStorage/FlyDB/assets/56055887/ddf02371-50a5-443c-9c2e-1e54e262616b)
![5dfbe7582575e5258634b135150925f](https://github.com/ByteStorage/FlyDB/assets/56055887/24daa108-f89f-40c6-ae46-b5827bda4aaa)
![7513123163cd377eb15bd5d7313cfe8](https://github.com/ByteStorage/FlyDB/assets/56055887/e33c484e-92f9-40ef-ac9f-103c5177b0cc)
![ab4100fd5d42a54a5ada166d2e62972](https://github.com/ByteStorage/FlyDB/assets/56055887/1b7aa1cf-6ee5-4876-963c-8ac4d7bbc01b)
![bf8e87f549b9eb527a80e6183b7e739](https://github.com/ByteStorage/FlyDB/assets/56055887/38c63f7f-1631-4d31-a7df-f35f44cfab30)
![a7866596a2e28efecd080f635ec9fca](https://github.com/ByteStorage/FlyDB/assets/56055887/db3898b6-af43-4e3f-8479-d5b3cbd71748)
![bb6437a33d669da683b57c26cebb1ca](https://github.com/ByteStorage/FlyDB/assets/56055887/3096c3d7-09f3-4261-99d3-d307829fceac)
![c3d97a7e1783acaf4d1554e8ba484aa](https://github.com/ByteStorage/FlyDB/assets/56055887/ea7cd1c6-f909-4636-9494-33409b144f26)
![3a37af2075f4e0e2b662d592a660550](https://github.com/ByteStorage/FlyDB/assets/56055887/b4435d9e-bbfc-4eb8-856e-ea97e204f518)
