### PR TITLE
Region AddPeer function implementation (#126)

### DIFF
--- a/cluster/region/region.go
+++ b/cluster/region/region.go
@@ -1,6 +1,7 @@
 package region
 
 import (
+	"errors"
 	"github.com/ByteStorage/FlyDB/engine"
 	"github.com/hashicorp/raft"
 	"sync"
@@ -93,7 +94,21 @@ func (r *region) TransferLeader(peer string) error {
 }
 
 func (r *region) AddPeer(peer string) error {
-	panic("implement me")
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	contains := func(arr []string, it string) bool {
+		for _, n := range arr {
+			if n == it {
+				return true
+			}
+		}
+		return false
+	}
+	if !contains(r.peers, peer) {
+		r.peers = append(r.peers, peer)
+		return r.raft.AddVoter(raft.ServerID(peer), raft.ServerAddress(peer), 0, 0).Error()
+	}
+	return errors.New("peer already exists")
 }
 
 func (r *region) RemovePeer(peer string) error {

--- a/cluster/region/region_test.go
+++ b/cluster/region/region_test.go
@@ -121,3 +121,32 @@ func TestRegion_GetSize(t *testing.T) {
 	size := region.GetSize()
 	assert.Equal(t, int64(100), size)
 }
+
+func TestRegion_AddPeer(t *testing.T) {
+	// Create a test region instance
+	region := NewTestRegion()
+	_ = []struct {
+		name          string
+		peers         []string
+		peerToAdd     string
+		expectedPeers []string
+		expectError   bool
+	}{
+		{
+			name:          "add a new peer",
+			peers:         region.GetPeers(),
+			peerToAdd:     "peer3",
+			expectedPeers: []string{"peer1", "peer2", "peer3"},
+			expectError:   false,
+		},
+		{
+			name:          "add duplicate peer",
+			peers:         region.GetPeers(),
+			peerToAdd:     "peer1",
+			expectedPeers: []string{"peer1", "peer2"},
+			expectError:   true,
+		},
+	}
+	destroyRegion(region)
+
+}


### PR DESCRIPTION
The implemented function `AddPeer`; searches `r.peers` for a similar peer and, if one exists, returns an error. There are two caveats:
- Implemented the unit test using table-style testing, which I hope is okay.
- In errors, I did not see a standard wording or style, so I chose a generic message.
#126 