### PR TITLE
Rewrite the LogStore component of raft (#177)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-
+      - name: Install Dependency
+        run: sudo apt-get update && sudo apt-get -y install librocksdb-dev
       - name: Check Format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
 

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -85,7 +85,10 @@ func (s *store) newRaftNode() error {
 	snapshots := newSnapshot()
 
 	// create the log store and stable store
-	logStore := newRaftLog()
+	logStore, err := newRaftLog()
+	if err != nil {
+		return err
+	}
 	stableStore := newStableLog()
 
 	// create a new finite state machine

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"errors"
 	"github.com/ByteStorage/FlyDB/cluster/region"
+	"github.com/ByteStorage/FlyDB/config"
 	"github.com/hashicorp/raft"
 	"sync"
 )
@@ -12,7 +13,9 @@ import (
 // Each region under the store is in a raftGroups, and the region clusters in the raftGroups communicate through grpc
 // store stores the data of a store.
 type store struct {
-	id         string                    // store id
+	id         string // store id
+	conf       config.Config
+	opts       config.Options
 	addr       string                    // store address
 	regionList map[uint64]*region.Region // region list, to store the regions in the store.
 	size       int64                     // size
@@ -76,7 +79,7 @@ func (s *store) newRaftNode() error {
 	// All new methods below can add other return values as needed, such as err
 
 	// setup Raft configuration
-	config := s.newDefaultConfig()
+	conf := s.newDefaultConfig()
 
 	// setup Raft communication
 	t := newTransport()
@@ -85,7 +88,7 @@ func (s *store) newRaftNode() error {
 	snapshots := newSnapshot()
 
 	// create the log store and stable store
-	logStore, err := newRaftLog()
+	logStore, err := newRaftLog(s.conf)
 	if err != nil {
 		return err
 	}
@@ -95,7 +98,7 @@ func (s *store) newRaftNode() error {
 	f := newFSM()
 
 	// instantiate the Raft system
-	r, err := raft.NewRaft(config, f, logStore, stableStore, snapshots, t)
+	r, err := raft.NewRaft(conf, f, logStore, stableStore, snapshots, t)
 	if err != nil {
 		return err
 	}

--- a/cluster/store/store_log.go
+++ b/cluster/store/store_log.go
@@ -1,45 +1,83 @@
 package store
 
-import "github.com/hashicorp/raft"
+import (
+	"fmt"
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/ByteStorage/FlyDB/lib/datastore"
+	"github.com/hashicorp/raft"
+)
 
-// raftLog implements raft.LogStore interface, we can use it to store raft logs
-// how to store raft logs? we can use FlyDB/RocksDB/LevelDB/BoltDB to store raft logs
-// maybe we can use FlyDB
-type raftLog struct {
-	// implement me
+// DataStoreFactory is a function type that creates a new instance of a raft.LogStore.
+// It takes a configuration map as input and returns the created LogStore or an error if the creation fails.
+type DataStoreFactory func(conf config.Options) (raft.LogStore, error)
+
+// datastoreFactories is a map that associates a string key (name) with a DataStoreFactory.
+// It will be used to store and retrieve different DataStoreFactory implementations.
+var datastoreFactories = make(map[string]DataStoreFactory)
+
+// Init initializes the datastoreFactories by registering different DataStoreFactory implementations.
+// It calls the Register function to associate each implementation with a unique name.
+// Currently, "memory" and "bolt" are registered as the names for the corresponding factories.
+// The function returns an error if any registration fails, but in this implementation, the error is ignored.
+func Init() error {
+	// Register the "memory" DataStoreFactory implementation with the name "memory"
+	_ = Register("memory", datastore.NewLogInMemStorage)
+	// Register the "bolt" DataStoreFactory implementation with the name "boltdb"
+	_ = Register("boltdb", datastore.NewLogBoltDbStorage)
+	// Register the "flydb" DataStoreFactory implementation with the name "flydb"
+	_ = Register("flydb", datastore.NewLogFlyDbStorage)
+	// Register the "rocksdb" DataStoreFactory implementation with the name "rocksdb"
+	_ = Register("rocksdb", datastore.NewLogRocksDbStorage)
+
+	return nil
 }
 
-// newRaftLog returns a new raftLog
-func newRaftLog() raft.LogStore {
-	return &raftLog{}
+// newRaftLog is a function that returns a new instance of raft.LogStore.
+// It initializes the datastoreFactories by calling the Init function.
+// Then, it retrieves the "memory" DataStoreFactory from the datastoreFactories map using the "memory" string key.
+// Finally, it creates a new LogStore using the retrieved factory and an empty configuration map.
+// The created LogStore and an error (if any) are returned.
+func newRaftLog() (raft.LogStore, error) {
+	_ = Init()
+
+	// Get the "memory" DataStoreFactory from the map
+	return getDataStore("memory", config.Options{})
 }
 
-func (r *raftLog) FirstIndex() (uint64, error) {
-	//TODO implement me
-	panic("implement me")
+// Register is a function that registers a DataStoreFactory implementation with a given name.
+// It takes the name string and the factory function as input.
+// The function checks if the factory is nil and returns an error if it is.
+// Then, it checks if the name is already registered in the datastoreFactories map.
+// If the name is already registered, it returns an error.
+// Otherwise, it adds the factory to the map with the name as the key and returns nil.
+func Register(name string, factory DataStoreFactory) error {
+	if factory == nil {
+		return fmt.Errorf("datastore factory %s does not exist", name)
+	}
+
+	// Check if the name is already registered
+	_, registered := datastoreFactories[name]
+	if registered {
+		return fmt.Errorf(`datastore factory %s already registered`, name)
+	}
+	// Add the factory to the datastoreFactories map
+	datastoreFactories[name] = factory
+	return nil
 }
 
-func (r *raftLog) LastIndex() (uint64, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r *raftLog) GetLog(index uint64, log *raft.Log) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r *raftLog) StoreLog(log *raft.Log) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r *raftLog) StoreLogs(logs []*raft.Log) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r *raftLog) DeleteRange(min, max uint64) error {
-	//TODO implement me
-	panic("implement me")
+// getDataStore is a function that retrieves a LogStore implementation from the datastoreFactories map.
+// It takes the name of the datastore and a configuration map as input.
+// The function first checks if the requested datastore exists in the map.
+// If the datastore is not found, it returns an error.
+// Otherwise, it retrieves the corresponding DataStoreFactory from the map.
+// Finally, it creates a new LogStore using the factory and the configuration map and returns it
+// along with an error (if any).
+func getDataStore(datastore string, conf config.Options) (raft.LogStore, error) {
+	// Get the DataStoreFactory for the requested datastore
+	dsFactory, ok := datastoreFactories[datastore]
+	if !ok {
+		return nil, fmt.Errorf("datastore not valid")
+	}
+	// Create a new LogStore using the DataStoreFactory and the configuration map
+	return dsFactory(conf)
 }

--- a/cluster/store/store_log.go
+++ b/cluster/store/store_log.go
@@ -9,7 +9,7 @@ import (
 
 // DataStoreFactory is a function type that creates a new instance of a raft.LogStore.
 // It takes a configuration map as input and returns the created LogStore or an error if the creation fails.
-type DataStoreFactory func(conf config.Options) (raft.LogStore, error)
+type DataStoreFactory func(conf config.Config) (raft.LogStore, error)
 
 // datastoreFactories is a map that associates a string key (name) with a DataStoreFactory.
 // It will be used to store and retrieve different DataStoreFactory implementations.
@@ -37,11 +37,11 @@ func Init() error {
 // Then, it retrieves the "memory" DataStoreFactory from the datastoreFactories map using the "memory" string key.
 // Finally, it creates a new LogStore using the retrieved factory and an empty configuration map.
 // The created LogStore and an error (if any) are returned.
-func newRaftLog() (raft.LogStore, error) {
+func newRaftLog(conf config.Config) (raft.LogStore, error) {
 	_ = Init()
 
 	// Get the "memory" DataStoreFactory from the map
-	return getDataStore("memory", config.Options{})
+	return getDataStore(conf)
 }
 
 // Register is a function that registers a DataStoreFactory implementation with a given name.
@@ -72,12 +72,12 @@ func Register(name string, factory DataStoreFactory) error {
 // Otherwise, it retrieves the corresponding DataStoreFactory from the map.
 // Finally, it creates a new LogStore using the factory and the configuration map and returns it
 // along with an error (if any).
-func getDataStore(datastore string, conf config.Options) (raft.LogStore, error) {
+func getDataStore(datastore config.Config) (raft.LogStore, error) {
 	// Get the DataStoreFactory for the requested datastore
-	dsFactory, ok := datastoreFactories[datastore]
+	dsFactory, ok := datastoreFactories[datastore.LogDataStorage]
 	if !ok {
 		return nil, fmt.Errorf("datastore not valid")
 	}
 	// Create a new LogStore using the DataStoreFactory and the configuration map
-	return dsFactory(conf)
+	return dsFactory(datastore)
 }

--- a/cluster/store/store_log_test.go
+++ b/cluster/store/store_log_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/ByteStorage/FlyDB/lib/datastore"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestRegister(t *testing.T) {
+	foo := func(conf config.Options) (raft.LogStore, error) {
+		return &datastore.InMemStore{}, nil
+	}
+	conf := config.Options{}
+	err := Register("memory", foo)
+	assert.NoError(t, err)
+	// get the datastore and check
+	ds, err := getDataStore("memory", conf)
+	assert.NoError(t, err)
+	assert.IsType(t, &datastore.InMemStore{}, ds)
+}
+
+func TestInit(t *testing.T) {
+	// initialize the dbs
+	_ = Init()
+	// in memory DB
+	conf := config.DefaultOptions
+	ds, err := getDataStore("memory", conf)
+	assert.NoError(t, err)
+	assert.IsType(t, &datastore.InMemStore{}, ds)
+	// FlyDB
+	tf, err := testTempFile()
+	assert.NoError(t, err)
+	conf.DirPath = tf
+	ds, err = getDataStore("flydb", conf)
+	assert.NoError(t, err)
+	assert.IsType(t, &datastore.FlyDbStore{}, ds)
+	// RockDB
+	tf, err = testTempDir()
+	assert.NoError(t, err)
+	conf.DirPath = tf
+	ds, err = getDataStore("rocksdb", conf)
+	assert.NoError(t, err)
+	assert.IsType(t, &datastore.RocksDbStore{}, ds)
+	// BoltDB
+	tf, err = testTempFile()
+	assert.NoError(t, err)
+	conf.DirPath = tf
+	ds, err = getDataStore("boltdb", conf)
+	assert.NoError(t, err)
+	assert.IsType(t, &datastore.BoltDbStore{}, ds)
+
+}
+
+func testTempFile() (string, error) {
+	tmpFile, err := os.CreateTemp("", "test_flydb_storage")
+	if err != nil {
+		return "", err
+	}
+	err = os.Remove(tmpFile.Name())
+	if err != nil {
+		return "", err
+	}
+	return tmpFile.Name(), nil
+}
+func testTempDir() (string, error) {
+	tmpDir, err := os.MkdirTemp("", "test_flydb_rocksDB")
+	if err != nil {
+		return "", err
+	}
+	err = os.Remove(tmpDir)
+	if err != nil {
+		return "", err
+	}
+	return tmpDir, nil
+}

--- a/config/cluster_options.go
+++ b/config/cluster_options.go
@@ -6,5 +6,8 @@ type Config struct {
 	ReplicationFactor  int
 	ShardingStrategy   string
 	SchedulingStrategy string
+	LogDataStorage     string
+	LogDataStoragePath string
+	LogDataStorageSize int64
 	HeartbeatInterval  time.Duration
 }

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,17 @@ go 1.18
 
 require (
 	github.com/bits-and-blooms/bitset v1.8.0
+	github.com/boltdb/bolt v1.3.1
 	github.com/desertbit/grumble v1.1.3
 	github.com/fatih/color v1.13.0
 	github.com/google/btree v1.1.2
+	github.com/hashicorp/go-msgpack v0.5.5
 	github.com/hashicorp/raft v1.5.0
 	github.com/hashicorp/raft-boltdb v0.0.0-20230125174641-2a8082862702
-	github.com/kelindar/bitmap v1.5.1
 	github.com/klauspost/reedsolomon v1.11.7
 	github.com/plar/go-adaptive-radix-tree v1.0.5
 	github.com/stretchr/testify v1.8.2
+	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c
 	github.com/tidwall/wal v1.1.7
 	go.etcd.io/bbolt v1.3.7
 	go.uber.org/zap v1.24.0
@@ -22,20 +24,20 @@ require (
 
 require (
 	github.com/armon/go-metrics v0.4.1 // indirect
-	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/desertbit/closer/v3 v3.1.2 // indirect
 	github.com/desertbit/columnize v2.1.0+incompatible // indirect
 	github.com/desertbit/go-shlex v0.1.1 // indirect
 	github.com/desertbit/readline v1.5.1 // indirect
+	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
+	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
+	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
-	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/kelindar/simd v1.1.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,12 @@ github.com/desertbit/grumble v1.1.3 h1:gbdgVGWsHmNraJ7Gn6Q4TiUEIHU/UHfbc1KUSbBlg
 github.com/desertbit/grumble v1.1.3/go.mod h1:r7j3ShNy5EmOsegRD2DzTutIaGiLiA3M5yBTXXeLwcs=
 github.com/desertbit/readline v1.5.1 h1:/wOIZkWYl1s+IvJm/5bOknfUgs6MhS9svRNZpFM53Os=
 github.com/desertbit/readline v1.5.1/go.mod h1:pHQgTsCFs9Cpfh5mlSUFi9Xa5kkL4d8L1Jo4UVWzPw0=
+github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=
+github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
+github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
+github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
+github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
+github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -95,10 +101,6 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/kelindar/bitmap v1.5.1 h1:+ZmZdwHbJ+CGE+q/aAJ74KJSnp0vOlGD7KY5x51mVzk=
-github.com/kelindar/bitmap v1.5.1/go.mod h1:j3qZjxH9s4OtvsnFTP2bmPkjqil9Y2xQlxPYHexasEA=
-github.com/kelindar/simd v1.1.2 h1:KduKb+M9cMY2HIH8S/cdJyD+5n5EGgq+Aeeleos55To=
-github.com/kelindar/simd v1.1.2/go.mod h1:inq4DFudC7W8L5fhxoeZflLRNpWSs0GNx6MlWFvuvr0=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/reedsolomon v1.11.7 h1:9uaHU0slncktTEEg4+7Vl7q7XUNMBUOK4R9gnKhMjAU=
@@ -176,6 +178,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/lib/datastore/boltdb.go
+++ b/lib/datastore/boltdb.go
@@ -1,0 +1,201 @@
+package datastore
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/ByteStorage/FlyDB/lib/encoding"
+	"github.com/boltdb/bolt"
+	"github.com/hashicorp/raft"
+	"go.uber.org/zap"
+	"sync"
+)
+
+// Define byte slices for bucket names
+var (
+	bucketLogs = []byte("logs")
+	bucketConf = []byte("conf")
+)
+
+// BoltDbStore is a struct that implements the raft.LogStore interface
+// It uses BoltDB as the underlying storage and a read-write mutex for concurrency control
+type BoltDbStore struct {
+	mux  sync.RWMutex
+	conn *bolt.DB
+}
+
+// NewLogBoltDbStorage is a function that creates a new BoltDB store
+// It takes a configuration map as input and returns a raft.LogStore and an error
+func NewLogBoltDbStorage(conf config.Options) (raft.LogStore, error) {
+	filename := conf.DirPath
+	dbOpts := &bolt.Options{
+		ReadOnly: false, // Open the database in read-write mode
+	}
+	conn, err := bolt.Open(filename, 0600, dbOpts) // Open the BoltDB database
+	if err != nil {
+		return nil, err
+	}
+
+	b := &BoltDbStore{
+		conn: conn,
+	}
+	if err := b.init(); err != nil {
+		_ = b.conn.Close()
+		return nil, err
+	}
+	return b, nil
+}
+
+// init is a method on BoltDbStore that initializes the BoltDB store
+// It creates the necessary buckets if they don't exist
+func (ds *BoltDbStore) init() error {
+	ds.mux.RLock()
+	defer ds.mux.RUnlock()
+	tx, err := ds.conn.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer check(tx.Rollback)
+
+	// Create necessary buckets if they don't exist
+	if _, err := tx.CreateBucketIfNotExists(bucketLogs); err != nil {
+		return err
+	}
+	if _, err := tx.CreateBucketIfNotExists(bucketConf); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// FirstIndex is a method on BoltDbStore that returns the first index in the log
+func (ds *BoltDbStore) FirstIndex() (uint64, error) {
+	tx, err := ds.conn.Begin(false)
+	if err != nil {
+		return 0, err
+	}
+	defer check(tx.Rollback)
+	var (
+		key []byte
+		idx uint64
+	)
+	curs := tx.Bucket(bucketLogs).Cursor()
+	key, _ = curs.First() // Retrieve the first key in the bucket
+	if key != nil {
+		idx = binary.BigEndian.Uint64(key)
+	}
+
+	return idx, nil
+}
+
+// LastIndex is a method on BoltDbStore that returns the last index in the log
+func (ds *BoltDbStore) LastIndex() (uint64, error) {
+	tx, err := ds.conn.Begin(false)
+	if err != nil {
+		return 0, err
+	}
+	defer check(tx.Rollback)
+	var (
+		key []byte
+		idx uint64
+	)
+	curs := tx.Bucket(bucketLogs).Cursor() // Get a cursor for the logs bucket
+	key, _ = curs.Last()                   // Retrieve the last key in the bucket
+	if key != nil {
+		idx = binary.BigEndian.Uint64(key) // Convert the key from bytes to uint64
+	}
+
+	return idx, nil
+}
+
+// GetLog is a method on BoltDbStore that retrieves a log entry by its index
+func (ds *BoltDbStore) GetLog(index uint64, log *raft.Log) error {
+	ds.mux.RLock()
+	defer ds.mux.RUnlock()
+	tx, err := ds.conn.Begin(false) // Start a read-only transaction
+	if err != nil {
+		return err
+	}
+	defer check(tx.Rollback)
+
+	bucket := tx.Bucket(bucketLogs)         // Get the logs bucket
+	val := bucket.Get(uint64ToBytes(index)) // Retrieve the log entry by index
+
+	if val == nil {
+		return raft.ErrLogNotFound // Return an error if the log entry is not found
+	}
+	return encoding.DecodeMessagePack(val, log) // Decode the log entry and assign it to the log variable
+}
+
+// StoreLog is a method on BoltDbStore that stores a single log entry
+func (ds *BoltDbStore) StoreLog(log *raft.Log) error {
+	return ds.StoreLogs([]*raft.Log{log}) // Call the StoreLogs method with a single log entry
+}
+
+// StoreLogs is a method on BoltDbStore that stores multiple log entries
+func (ds *BoltDbStore) StoreLogs(logs []*raft.Log) error {
+	tx, err := ds.conn.Begin(true) // Start a read-write transaction
+	if err != nil {
+		return err
+	}
+	defer check(tx.Rollback)
+	bucket := tx.Bucket(bucketLogs)
+	for _, log := range logs {
+		var (
+			key []byte
+			val []byte
+		)
+		key = uint64ToBytes(log.Index)             // Convert the index to bytes
+		val, err = encoding.EncodeMessagePack(log) // Encode the log entry
+		if err != nil {
+			break
+		}
+		err = bucket.Put(key[:], val)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit() // Commit the transaction
+}
+
+// DeleteRange is a method on BoltDbStore that deletes a range of log entries
+func (ds *BoltDbStore) DeleteRange(min, max uint64) error {
+	tx, err := ds.conn.Begin(true) // Start a read-write transaction
+	if err != nil {
+		return err
+	}
+	key := uint64ToBytes(min)
+
+	defer check(tx.Rollback)
+	curs := tx.Bucket(bucketLogs).Cursor()
+	for k, _ := curs.Seek(key[:]); k != nil; k, _ = curs.Next() {
+		// If we reach the max, we are done
+		if binary.BigEndian.Uint64(k) > max {
+			break
+		}
+		if err := curs.Delete(); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// uint64ToBytes is a helper function that converts an uint64 to a byte slice
+func uint64ToBytes(val uint64) []byte {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], val)
+	return b[:]
+}
+
+// uint64ToBytes is a helper function that converts an uint64 to a byte slice
+func bytesToUint64(val []byte) uint64 {
+	return binary.BigEndian.Uint64(val)
+}
+
+func check(f func() error) {
+	if err := f(); err != nil {
+		// todo create a central logging solution
+		zap.L().Log(zap.ErrorLevel, fmt.Sprintf("Received error:%s", err))
+	}
+}

--- a/lib/datastore/boltdb.go
+++ b/lib/datastore/boltdb.go
@@ -26,8 +26,8 @@ type BoltDbStore struct {
 
 // NewLogBoltDbStorage is a function that creates a new BoltDB store
 // It takes a configuration map as input and returns a raft.LogStore and an error
-func NewLogBoltDbStorage(conf config.Options) (raft.LogStore, error) {
-	filename := conf.DirPath
+func NewLogBoltDbStorage(conf config.Config) (raft.LogStore, error) {
+	filename := conf.LogDataStoragePath
 	dbOpts := &bolt.Options{
 		ReadOnly: false, // Open the database in read-write mode
 	}

--- a/lib/datastore/boltdb_test.go
+++ b/lib/datastore/boltdb_test.go
@@ -1,0 +1,166 @@
+package datastore
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func testBoltDatastore() (raft.LogStore, error) {
+	tmpFile, err := os.CreateTemp("", "test_flydb_boltdb")
+	if err != nil {
+		return nil, err
+	}
+	err = os.Remove(tmpFile.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	// Successfully creates and returns a store
+
+	return NewLogBoltDbStorage(config.Options{DirPath: tmpFile.Name()})
+}
+
+func TestBoltDbStore_DeleteRange(t *testing.T) {
+	r, err := testBoltDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	var log1, log2, log3, log4 raft.Log
+	_ = r.GetLog(23, &log1)
+	assert.Equal(t, *logs[2], log1)
+
+	_ = r.DeleteRange(9, 50)
+	assert.NoError(t, err)
+	_ = r.GetLog(23, &log2)
+	assert.Equal(t, raft.Log{}, log2)
+	// delete another range
+	_ = r.GetLog(2, &log3)
+	assert.Equal(t, *logs[1], log3)
+
+	_ = r.DeleteRange(2, 5)
+	assert.NoError(t, err)
+	_ = r.GetLog(2, &log4)
+	assert.Equal(t, raft.Log{}, log4)
+}
+func TestBoltDbStore_FirstIndex(t *testing.T) {
+	r, err := testBoltDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(8, "test2"),
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	fi, err := r.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, fi)
+	// remove first element
+	_ = r.DeleteRange(1, 2)
+	fi, err = r.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 8, fi)
+
+}
+func TestBoltDbStore_LastIndex(t *testing.T) {
+	r, err := testBoltDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	//
+	li, err := r.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 23, li)
+	// remove first element
+	_ = r.DeleteRange(9, 50)
+	li, err = r.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 6, li)
+
+}
+func TestBoltDbStore_GetLog(t *testing.T) {
+	r, err := testBoltDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log raft.Log
+	err = r.GetLog(1, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[0])
+	// get log of id 23
+	err = r.GetLog(23, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[2])
+
+}
+func TestBoltDbStore_StoreLog(t *testing.T) {
+	r, err := testBoltDatastore()
+	assert.NoError(t, err)
+
+	l1 := createRaftLog(23, "test4")
+	err = r.StoreLog(l1)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log5 raft.Log
+	_ = r.GetLog(1, &log1)
+	_ = r.GetLog(23, &log3)
+	assert.NoError(t, err)
+
+	assert.Equal(t, log1, raft.Log{})
+	assert.Equal(t, log2, raft.Log{})
+	assert.Equal(t, log3, *l1)
+
+	// check for errors
+	err = r.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}
+func TestBoltDbStore_StoreLogs(t *testing.T) {
+	r, err := testBoltDatastore()
+	assert.NoError(t, err)
+
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+		createRaftLog(8, "test2"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log5 raft.Log
+	_ = r.GetLog(1, &log1)
+	_ = r.GetLog(23, &log2)
+	_ = r.GetLog(8, &log3)
+
+	assert.Equal(t, log1, *logs[0])
+	assert.Equal(t, log2, *logs[1])
+	assert.Equal(t, log3, *logs[2])
+
+	// check for errors
+	err = r.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}

--- a/lib/datastore/boltdb_test.go
+++ b/lib/datastore/boltdb_test.go
@@ -20,7 +20,7 @@ func testBoltDatastore() (raft.LogStore, error) {
 
 	// Successfully creates and returns a store
 
-	return NewLogBoltDbStorage(config.Options{DirPath: tmpFile.Name()})
+	return NewLogBoltDbStorage(config.Config{LogDataStoragePath: tmpFile.Name()})
 }
 
 func TestBoltDbStore_DeleteRange(t *testing.T) {

--- a/lib/datastore/flydb.go
+++ b/lib/datastore/flydb.go
@@ -1,0 +1,129 @@
+package datastore
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/ByteStorage/FlyDB/engine"
+	"github.com/ByteStorage/FlyDB/lib/encoding"
+	"github.com/hashicorp/raft"
+	"math"
+	"sync"
+)
+
+// FlyDbStore is a struct that implements the raft.LogStore interface
+// It uses FlyDB as the underlying storage and a read-write mutex for concurrency control
+type FlyDbStore struct {
+	mux        sync.RWMutex
+	conn       *engine.DB
+	firstIndex uint64
+	lastIndex  uint64
+}
+
+// NewLogFlyDbStorage is a function that creates a new FlyDB store
+// It takes a configuration map as input and returns a raft.LogStore and an error
+func NewLogFlyDbStorage(conf config.Options) (raft.LogStore, error) {
+	conn, err := engine.NewDB(conf)
+	if err != nil {
+		return nil, err
+	}
+	b := &FlyDbStore{
+		conn: conn,
+	}
+	return b, nil
+}
+
+// FirstIndex is a method on FlyDbStore that returns the first index in the log
+func (fds *FlyDbStore) FirstIndex() (uint64, error) {
+	return fds.firstIndex, nil
+}
+
+// LastIndex is a method on FlyDbStore that returns the last index in the log
+func (fds *FlyDbStore) LastIndex() (uint64, error) {
+	return fds.lastIndex, nil
+}
+
+// GetLog is a method on FlyDbStore that retrieves a log entry by its index
+func (fds *FlyDbStore) GetLog(index uint64, log *raft.Log) error {
+	val, err := fds.conn.Get(uint64ToBytes(index)) // Retrieve the log entry by index
+	if err != nil {
+		return err
+	}
+	if val == nil {
+		return raft.ErrLogNotFound // Return an error if the log entry is not found
+	}
+	return encoding.DecodeMessagePack(val, log) // Decode the log entry and assign it to the log variable
+}
+
+// StoreLog is a method on FlyDbStore that stores a single log entry
+func (fds *FlyDbStore) StoreLog(log *raft.Log) error {
+	return fds.StoreLogs([]*raft.Log{log}) // Call the StoreLogs method with a single log entry
+}
+
+// StoreLogs is a method on FlyDbStore that stores multiple log entries
+// since FlyDB currently does not support transactions,
+// please be aware that in case of errors, already written data will persist.
+func (fds *FlyDbStore) StoreLogs(logs []*raft.Log) error {
+
+	for _, log := range logs {
+		var (
+			key []byte
+			val []byte
+		)
+
+		key = uint64ToBytes(log.Index)              // Convert the index to bytes
+		val, err := encoding.EncodeMessagePack(log) // Encode the log entry
+		if err != nil {
+			break
+		}
+		err = fds.conn.Put(key[:], val)
+		if err != nil {
+			return err
+		}
+		if log.Index > fds.lastIndex {
+			fds.lastIndex = log.Index
+		} else if log.Index < fds.firstIndex || fds.firstIndex == 0 {
+			fds.firstIndex = log.Index
+		}
+	}
+
+	return nil
+}
+
+// DeleteRange is a method on FlyDbStore that deletes a range of log entries
+func (fds *FlyDbStore) DeleteRange(min, max uint64) error {
+	for i := min; i <= max; i++ {
+		_ = fds.conn.Delete(uint64ToBytes(i))
+	}
+	if fds.firstIndex >= min && fds.firstIndex <= max {
+		fds.firstIndex = fds.min()
+	}
+	if fds.lastIndex >= min && fds.lastIndex <= max {
+		fds.lastIndex = fds.max()
+	}
+
+	return nil
+}
+
+// min is a helper method on FlyDbStore that returns the smallest index in the log
+func (fds *FlyDbStore) min() uint64 {
+	var min uint64
+	min = math.MaxUint64
+	keys := fds.conn.GetListKeys()
+	for _, k := range keys {
+		if bytesToUint64(k) < min {
+			min = bytesToUint64(k)
+		}
+	}
+	return min
+}
+
+// max is a helper method on FlyDbStore that returns the largest index in the log
+func (fds *FlyDbStore) max() uint64 {
+	var max uint64
+	keys := fds.conn.GetListKeys()
+	for _, k := range keys {
+		if bytesToUint64(k) > max {
+			max = bytesToUint64(k)
+		}
+	}
+	return max
+}

--- a/lib/datastore/flydb.go
+++ b/lib/datastore/flydb.go
@@ -20,8 +20,11 @@ type FlyDbStore struct {
 
 // NewLogFlyDbStorage is a function that creates a new FlyDB store
 // It takes a configuration map as input and returns a raft.LogStore and an error
-func NewLogFlyDbStorage(conf config.Options) (raft.LogStore, error) {
-	conn, err := engine.NewDB(conf)
+func NewLogFlyDbStorage(conf config.Config) (raft.LogStore, error) {
+	opts := config.DefaultOptions
+	opts.DirPath = conf.LogDataStoragePath
+	opts.DataFileSize = conf.LogDataStorageSize
+	conn, err := engine.NewDB(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/datastore/flydb_test.go
+++ b/lib/datastore/flydb_test.go
@@ -1,0 +1,167 @@
+package datastore
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func testFlyDbDatastore() (raft.LogStore, error) {
+	tmpFile, err := os.CreateTemp("", "test_flydb_storage")
+	if err != nil {
+		return nil, err
+	}
+	err = os.Remove(tmpFile.Name())
+	if err != nil {
+		return nil, err
+	}
+	opts := config.DefaultOptions
+	opts.DataFileSize = 64 * 1024 * 1024
+	opts.DirPath = tmpFile.Name()
+	// Successfully creates and returns a store
+	return NewLogFlyDbStorage(opts)
+}
+
+func TestFlyDbStore_DeleteRange(t *testing.T) {
+	r, err := testFlyDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	var log1, log2, log3, log4 raft.Log
+	_ = r.GetLog(23, &log1)
+	assert.Equal(t, *logs[2], log1)
+
+	_ = r.DeleteRange(9, 50)
+	assert.NoError(t, err)
+	_ = r.GetLog(23, &log2)
+	assert.Equal(t, raft.Log{}, log2)
+	// delete another range
+	_ = r.GetLog(2, &log3)
+	assert.Equal(t, *logs[1], log3)
+
+	_ = r.DeleteRange(2, 5)
+	assert.NoError(t, err)
+	_ = r.GetLog(2, &log4)
+	assert.Equal(t, raft.Log{}, log4)
+}
+func TestFlyDbStore_FirstIndex(t *testing.T) {
+	r, err := testFlyDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(8, "test2"),
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	fi, err := r.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, fi)
+	// remove first element
+	_ = r.DeleteRange(1, 2)
+	fi, err = r.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 8, fi)
+
+}
+func TestFlyDbStore_LastIndex(t *testing.T) {
+	r, err := testFlyDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	//
+	li, err := r.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 23, li)
+	// remove first element
+	_ = r.DeleteRange(9, 50)
+	li, err = r.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 6, li)
+
+}
+func TestFlyDbStore_GetLog(t *testing.T) {
+	r, err := testFlyDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log raft.Log
+	err = r.GetLog(1, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[0])
+	// get log of id 23
+	err = r.GetLog(23, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[2])
+
+}
+func TestFlyDbStore_StoreLog(t *testing.T) {
+	r, err := testFlyDbDatastore()
+	assert.NoError(t, err)
+
+	l1 := createRaftLog(23, "test4")
+	err = r.StoreLog(l1)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log5 raft.Log
+	_ = r.GetLog(1, &log1)
+	_ = r.GetLog(23, &log3)
+	assert.NoError(t, err)
+
+	assert.Equal(t, log1, raft.Log{})
+	assert.Equal(t, log2, raft.Log{})
+	assert.Equal(t, log3, *l1)
+
+	// check for errors
+	err = r.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}
+func TestFlyDbStore_StoreLogs(t *testing.T) {
+	r, err := testFlyDbDatastore()
+	assert.NoError(t, err)
+
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+		createRaftLog(8, "test2"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log5 raft.Log
+	_ = r.GetLog(1, &log1)
+	_ = r.GetLog(23, &log2)
+	_ = r.GetLog(8, &log3)
+
+	assert.Equal(t, log1, *logs[0])
+	assert.Equal(t, log2, *logs[1])
+	assert.Equal(t, log3, *logs[2])
+
+	// check for errors
+	err = r.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}

--- a/lib/datastore/flydb_test.go
+++ b/lib/datastore/flydb_test.go
@@ -17,9 +17,9 @@ func testFlyDbDatastore() (raft.LogStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	opts := config.DefaultOptions
-	opts.DataFileSize = 64 * 1024 * 1024
-	opts.DirPath = tmpFile.Name()
+	opts := config.Config{}
+	opts.LogDataStorageSize = 64 * 1024 * 1024
+	opts.LogDataStoragePath = tmpFile.Name()
 	// Successfully creates and returns a store
 	return NewLogFlyDbStorage(opts)
 }

--- a/lib/datastore/inmem.go
+++ b/lib/datastore/inmem.go
@@ -1,0 +1,118 @@
+package datastore
+
+import (
+	"errors"
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/hashicorp/raft"
+	"math"
+	"sync"
+)
+
+// InMemStore is a struct that implements the raft.LogStore interface
+// It uses a map as the underlying storage and a read-write mutex for concurrency control
+type InMemStore struct {
+	mux        sync.RWMutex
+	firstIndex uint64
+	lastIndex  uint64
+	logs       map[uint64]*raft.Log
+}
+
+// NewLogInMemStorage is a function that creates a new in-memory store
+// It returns a raft.LogStore and an error
+func NewLogInMemStorage(conf config.Options) (raft.LogStore, error) {
+	a := &InMemStore{
+		logs: make(map[uint64]*raft.Log),
+	}
+	return a, nil
+}
+
+// FirstIndex is a method on InMemStore that returns the first index in the log
+func (ds *InMemStore) FirstIndex() (uint64, error) {
+	ds.mux.RLock()
+	defer ds.mux.RUnlock()
+	return ds.firstIndex, nil
+}
+
+// LastIndex is a method on InMemStore that returns the last index in the log
+func (ds *InMemStore) LastIndex() (uint64, error) {
+	ds.mux.RLock()
+	defer ds.mux.RUnlock()
+	return ds.lastIndex, nil
+}
+
+// GetLog is a method on InMemStore that retrieves a log entry by its index
+func (ds *InMemStore) GetLog(index uint64, log *raft.Log) error {
+	ds.mux.RLock()
+	defer ds.mux.RUnlock()
+	l, ok := ds.logs[index]
+	if !ok {
+		return errors.New("InMem Log Store: log with index not found")
+	}
+	*log = *l
+	return nil
+}
+
+// StoreLog is a method on InMemStore that stores a single log entry
+func (ds *InMemStore) StoreLog(log *raft.Log) error {
+	return ds.StoreLogs([]*raft.Log{log})
+}
+
+// StoreLogs is a method on InMemStore that stores multiple log entries
+func (ds *InMemStore) StoreLogs(logs []*raft.Log) error {
+	ds.mux.Lock()
+	defer ds.mux.Unlock()
+	for _, l := range logs {
+		ds.logs[l.Index] = l
+		if ds.firstIndex == 0 {
+			ds.firstIndex = l.Index
+		}
+		if l.Index > ds.lastIndex {
+			ds.lastIndex = l.Index
+		}
+		if l.Index < ds.firstIndex {
+			ds.firstIndex = l.Index
+		}
+	}
+	return nil
+}
+
+// DeleteRange is a method on InMemStore that deletes a range of log entries
+func (ds *InMemStore) DeleteRange(min, max uint64) error {
+	ds.mux.Lock()
+	defer ds.mux.Unlock()
+	for j := min; j <= max; j++ {
+		delete(ds.logs, j)
+	}
+	if ds.firstIndex >= min && ds.firstIndex <= max {
+		ds.firstIndex = ds.min()
+	}
+	if ds.lastIndex >= min && ds.lastIndex <= max {
+		ds.lastIndex = ds.max()
+	}
+
+	return nil
+}
+
+// min is a helper method on InMemStore that returns the smallest index in the log
+func (ds *InMemStore) min() uint64 {
+	var min uint64
+	min = math.MaxUint64
+	for k := range ds.logs {
+		if k < min {
+			min = k
+		}
+	}
+	return min
+}
+
+// max is a helper method on InMemStore that returns the largest index in the log
+func (ds *InMemStore) max() uint64 {
+	var max uint64
+
+	for k := range ds.logs {
+		if k > max {
+			max = k
+		}
+	}
+	return max
+}

--- a/lib/datastore/inmem.go
+++ b/lib/datastore/inmem.go
@@ -19,7 +19,7 @@ type InMemStore struct {
 
 // NewLogInMemStorage is a function that creates a new in-memory store
 // It returns a raft.LogStore and an error
-func NewLogInMemStorage(conf config.Options) (raft.LogStore, error) {
+func NewLogInMemStorage(conf config.Config) (raft.LogStore, error) {
 	a := &InMemStore{
 		logs: make(map[uint64]*raft.Log),
 	}

--- a/lib/datastore/inmem_test.go
+++ b/lib/datastore/inmem_test.go
@@ -1,0 +1,156 @@
+package datastore
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func testMemoryDatastore() raft.LogStore {
+	ds, _ := NewLogInMemStorage(config.Options{})
+	return ds
+}
+func createRaftLog(idx uint64, data string) *raft.Log {
+	return &raft.Log{
+		Data:  []byte(data),
+		Index: idx,
+	}
+}
+
+func TestInMemStore_GetLog(t *testing.T) {
+	ds := testMemoryDatastore()
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+	}
+	err := ds.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log raft.Log
+	err = ds.GetLog(1, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[0])
+	// get log of id 23
+	err = ds.GetLog(23, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[2])
+}
+
+func TestInMemStore_DeleteRange(t *testing.T) {
+	ds := testMemoryDatastore()
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err := ds.StoreLogs(logs)
+	assert.NoError(t, err)
+	var log1, log2 raft.Log
+	_ = ds.GetLog(23, &log1)
+	assert.Equal(t, *logs[2], log1)
+
+	_ = ds.DeleteRange(9, 50)
+	assert.NoError(t, err)
+	_ = ds.GetLog(23, &log2)
+	assert.Equal(t, raft.Log{}, log2)
+
+}
+
+func TestInMemStore_StoreLog(t *testing.T) {
+	ds := testMemoryDatastore()
+
+	l1 := createRaftLog(6, "test4")
+	err := ds.StoreLog(l1)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log4, log5 raft.Log
+	_ = ds.GetLog(1, &log1)
+	_ = ds.GetLog(2, &log2)
+	_ = ds.GetLog(23, &log3)
+	err = ds.GetLog(6, &log4)
+	assert.NoError(t, err)
+
+	assert.Equal(t, log1, raft.Log{})
+	assert.Equal(t, log2, raft.Log{})
+	assert.Equal(t, log3, raft.Log{})
+	assert.Equal(t, log4, *l1)
+
+	// check for errors
+	err = ds.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}
+
+func TestInMemStore_StoreLogs(t *testing.T) {
+	ds := testMemoryDatastore()
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err := ds.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log4, log5 raft.Log
+	_ = ds.GetLog(1, &log1)
+	_ = ds.GetLog(2, &log2)
+	_ = ds.GetLog(23, &log3)
+	_ = ds.GetLog(6, &log4)
+
+	assert.Equal(t, log1, *logs[0])
+	assert.Equal(t, log2, *logs[1])
+	assert.Equal(t, log3, *logs[2])
+	assert.Equal(t, log4, *logs[3])
+
+	// check for errors
+	err = ds.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}
+
+func TestInMemStore_FirstIndex(t *testing.T) {
+	ds := testMemoryDatastore()
+	logs := []*raft.Log{
+		createRaftLog(8, "test2"),
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+	}
+	err := ds.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	fi, err := ds.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, fi)
+	// remove first element
+	_ = ds.DeleteRange(1, 2)
+	fi, err = ds.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 8, fi)
+
+}
+
+func TestInMemStore_LastIndex(t *testing.T) {
+	ds := testMemoryDatastore()
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err := ds.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	li, err := ds.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 23, li)
+	// remove first element
+	_ = ds.DeleteRange(9, 50)
+	li, err = ds.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 6, li)
+
+}

--- a/lib/datastore/inmem_test.go
+++ b/lib/datastore/inmem_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func testMemoryDatastore() raft.LogStore {
-	ds, _ := NewLogInMemStorage(config.Options{})
+	ds, _ := NewLogInMemStorage(config.Config{})
 	return ds
 }
 func createRaftLog(idx uint64, data string) *raft.Log {

--- a/lib/datastore/rocksdb.go
+++ b/lib/datastore/rocksdb.go
@@ -1,0 +1,116 @@
+package datastore
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/ByteStorage/FlyDB/lib/encoding"
+	"github.com/hashicorp/raft"
+	"github.com/tecbot/gorocksdb"
+	"sync"
+)
+
+// RocksDbStore is a struct that implements the raft.LogStore interface
+// It uses BoltDB as the underlying storage and a read-write mutex for concurrency control
+type RocksDbStore struct {
+	mux  sync.RWMutex
+	conn *gorocksdb.DB
+}
+
+// NewLogRocksDbStorage is a function that creates a new RocksDB store
+// It takes a configuration map as input and returns a raft.LogStore and an error
+func NewLogRocksDbStorage(conf config.Options) (raft.LogStore, error) {
+	filename := conf.DirPath
+	options := gorocksdb.NewDefaultOptions()
+	options.SetCreateIfMissing(true)
+	db, err := gorocksdb.OpenDb(options, filename)
+	if err != nil {
+		return nil, err
+	}
+	b := &RocksDbStore{
+		conn: db,
+	}
+
+	return b, nil
+}
+
+// FirstIndex is a method on RocksDbStore that returns the first index in the log
+func (rds *RocksDbStore) FirstIndex() (uint64, error) {
+	ro := gorocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+	it := rds.conn.NewIterator(ro)
+	it.SeekToFirst()
+	return bytesToUint64(it.Key().Data()), nil
+}
+
+// LastIndex is a method on RocksDbStore that returns the last index in the log
+func (rds *RocksDbStore) LastIndex() (uint64, error) {
+	ro := gorocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+	it := rds.conn.NewIterator(ro)
+	it.SeekToLast()
+	return bytesToUint64(it.Key().Data()), nil
+}
+
+// GetLog is a method on RocksDbStore that retrieves a log entry by its index
+func (rds *RocksDbStore) GetLog(index uint64, log *raft.Log) error {
+	ro := gorocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+
+	val, err := rds.conn.Get(ro, uint64ToBytes(index))
+	if err != nil {
+		return err
+	}
+	err = encoding.DecodeMessagePack(val.Data(), log)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// StoreLog is a method on RocksDbStore that stores a single log entry
+func (rds *RocksDbStore) StoreLog(log *raft.Log) error {
+	return rds.StoreLogs([]*raft.Log{log}) // Call the StoreLogs method with a single log entry
+}
+
+// StoreLogs is a method on RocksDbStore that stores multiple log entries
+func (rds *RocksDbStore) StoreLogs(logs []*raft.Log) error {
+	wo := gorocksdb.NewDefaultWriteOptions()
+	wb := gorocksdb.NewWriteBatch()
+	wo.SetSync(true)
+	defer func() {
+		wo.Destroy()
+		wb.Destroy()
+	}()
+	for _, log := range logs {
+		var (
+			key []byte
+			val []byte
+		)
+		key = uint64ToBytes(log.Index)              // Convert the index to bytes
+		val, err := encoding.EncodeMessagePack(log) // Encode the log entry
+		if err != nil {
+			return err
+		}
+		wb.Put(key, val)
+
+	}
+
+	return rds.conn.Write(wo, wb) // Commit the transaction
+}
+
+// DeleteRange is a method on RocksDbStore that deletes a range of log entries
+func (rds *RocksDbStore) DeleteRange(min, max uint64) error {
+	ro := gorocksdb.NewDefaultReadOptions()
+	wo := gorocksdb.NewDefaultWriteOptions()
+	wb := gorocksdb.NewWriteBatch()
+	defer func() {
+		ro.Destroy()
+		wo.Destroy()
+		wb.Destroy()
+	}()
+	wb.DeleteRange(uint64ToBytes(min), uint64ToBytes(max))
+	err := rds.conn.Write(wo, wb)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/datastore/rocksdb.go
+++ b/lib/datastore/rocksdb.go
@@ -17,8 +17,8 @@ type RocksDbStore struct {
 
 // NewLogRocksDbStorage is a function that creates a new RocksDB store
 // It takes a configuration map as input and returns a raft.LogStore and an error
-func NewLogRocksDbStorage(conf config.Options) (raft.LogStore, error) {
-	filename := conf.DirPath
+func NewLogRocksDbStorage(conf config.Config) (raft.LogStore, error) {
+	filename := conf.LogDataStoragePath
 	options := gorocksdb.NewDefaultOptions()
 	options.SetCreateIfMissing(true)
 	db, err := gorocksdb.OpenDb(options, filename)

--- a/lib/datastore/rocksdb_test.go
+++ b/lib/datastore/rocksdb_test.go
@@ -1,0 +1,167 @@
+package datastore
+
+import (
+	"github.com/ByteStorage/FlyDB/config"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func testRocksDbDatastore() (raft.LogStore, error) {
+	//fmt.Sprintf("%s/%s", os.TempDir, "")
+	tmpDir, err := os.MkdirTemp("", "test_flydb_rocksDB")
+	if err != nil {
+		return nil, err
+	}
+	err = os.Remove(tmpDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Successfully creates and returns a store
+
+	return NewLogRocksDbStorage(config.Options{DirPath: tmpDir})
+}
+
+func TestRocksDbStore_DeleteRange(t *testing.T) {
+	r, err := testRocksDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	var log1, log2, log3, log4 raft.Log
+	_ = r.GetLog(23, &log1)
+	assert.Equal(t, *logs[2], log1)
+
+	_ = r.DeleteRange(9, 50)
+	assert.NoError(t, err)
+	_ = r.GetLog(23, &log2)
+	assert.Equal(t, raft.Log{}, log2)
+	// delete another range
+	_ = r.GetLog(2, &log3)
+	assert.Equal(t, *logs[1], log3)
+
+	_ = r.DeleteRange(2, 5)
+	assert.NoError(t, err)
+	_ = r.GetLog(2, &log4)
+	assert.Equal(t, raft.Log{}, log4)
+}
+func TestRocksDbStore_FirstIndex(t *testing.T) {
+	r, err := testRocksDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(8, "test2"),
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	fi, err := r.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, fi)
+	// remove first element
+	_ = r.DeleteRange(1, 2)
+	fi, err = r.FirstIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 8, fi)
+
+}
+func TestRocksDbStore_LastIndex(t *testing.T) {
+	r, err := testRocksDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+		createRaftLog(6, "test4"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+
+	//
+	li, err := r.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 23, li)
+	// remove first element
+	_ = r.DeleteRange(9, 50)
+	li, err = r.LastIndex()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 6, li)
+
+}
+func TestRocksDbStore_GetLog(t *testing.T) {
+	r, err := testRocksDbDatastore()
+	assert.NoError(t, err)
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(2, "test2"),
+		createRaftLog(23, "test3"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log raft.Log
+	err = r.GetLog(1, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[0])
+	// get log of id 23
+	err = r.GetLog(23, &log)
+	assert.NoError(t, err)
+	assert.Equal(t, log, *logs[2])
+
+}
+func TestRocksDbStore_StoreLog(t *testing.T) {
+	r, err := testRocksDbDatastore()
+	assert.NoError(t, err)
+
+	l1 := createRaftLog(23, "test4")
+	err = r.StoreLog(l1)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log5 raft.Log
+	_ = r.GetLog(1, &log1)
+	_ = r.GetLog(23, &log3)
+	assert.NoError(t, err)
+
+	assert.Equal(t, log1, raft.Log{})
+	assert.Equal(t, log2, raft.Log{})
+	assert.Equal(t, log3, *l1)
+
+	// check for errors
+	err = r.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}
+func TestRocksDbStore_StoreLogs(t *testing.T) {
+	r, err := testRocksDbDatastore()
+	assert.NoError(t, err)
+
+	logs := []*raft.Log{
+		createRaftLog(1, "test1"),
+		createRaftLog(23, "test3"),
+		createRaftLog(8, "test2"),
+	}
+	err = r.StoreLogs(logs)
+	assert.NoError(t, err)
+	// get the logs
+	var log1, log2, log3, log5 raft.Log
+	_ = r.GetLog(1, &log1)
+	_ = r.GetLog(23, &log2)
+	_ = r.GetLog(8, &log3)
+
+	assert.Equal(t, log1, *logs[0])
+	assert.Equal(t, log2, *logs[1])
+	assert.Equal(t, log3, *logs[2])
+
+	// check for errors
+	err = r.GetLog(4, &log5)
+	assert.True(t, err != nil)
+
+}

--- a/lib/datastore/rocksdb_test.go
+++ b/lib/datastore/rocksdb_test.go
@@ -21,7 +21,7 @@ func testRocksDbDatastore() (raft.LogStore, error) {
 
 	// Successfully creates and returns a store
 
-	return NewLogRocksDbStorage(config.Options{DirPath: tmpDir})
+	return NewLogRocksDbStorage(config.Config{LogDataStoragePath: tmpDir})
 }
 
 func TestRocksDbStore_DeleteRange(t *testing.T) {

--- a/lib/encoding/messagepack.go
+++ b/lib/encoding/messagepack.go
@@ -1,0 +1,32 @@
+package encoding
+
+import (
+	"bytes"
+	"github.com/hashicorp/go-msgpack/codec"
+)
+
+// EncodeMessagePack is a function that encodes a given message using MessagePack serialization.
+// It takes an interface{} parameter representing the message and returns the encoded byte slice and an error.
+func EncodeMessagePack(msg interface{}) ([]byte, error) {
+	var b []byte
+	var mph codec.MsgpackHandle
+	h := &mph
+	enc := codec.NewEncoderBytes(&b, h) // Create a new encoder with the provided message and MessagePack handle
+
+	err := enc.Encode(msg) // Encode the message using the encoder
+	if err != nil {
+		return nil, err
+	}
+	return b, nil // Return the encoded byte slice
+}
+
+// DecodeMessagePack is a function that decodes a given byte slice using MessagePack deserialization.
+// It takes an input byte slice and an interface{} representing the output structure for the deserialized message.
+// It returns an error if the decoding process fails.
+func DecodeMessagePack(in []byte, out interface{}) error {
+	buf := bytes.NewBuffer(in) // Create a new buffer with the input byte slice
+	mph := codec.MsgpackHandle{}
+	dev := codec.NewDecoder(buf, &mph) // Create a new decoder with the buffer and MessagePack handle
+
+	return dev.Decode(out) // Decode the byte slice into the provided output structure
+}

--- a/lib/encoding/messagepack_test.go
+++ b/lib/encoding/messagepack_test.go
@@ -1,0 +1,18 @@
+package encoding
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEncodeMessagePack(t *testing.T) {
+	var data = &raft.Log{Index: 10, Data: []byte("helloWorld!")}
+	var decData raft.Log
+	d, err := EncodeMessagePack(data)
+	assert.NoError(t, err)
+	assert.NotNil(t, d)
+	err = DecodeMessagePack(d, &decData)
+	assert.NoError(t, err)
+	assert.Equal(t, decData, *data)
+}


### PR DESCRIPTION
Raft's `LogStore` functions are implemented in two ways: `InMemory,` `BoltDB,` `RocksDB,` and `FlyDB.` The configuration of the implementation can be done through a text-based format.
closes #177 